### PR TITLE
Don't use maxChunkSize if adaptive is false

### DIFF
--- a/ufs-uploader.js
+++ b/ufs-uploader.js
@@ -349,11 +349,6 @@ export class Uploader {
                         }
                     }
 
-                    // Limit to max chunk size
-                    if (self.maxChunkSize > 0 && chunkSize > self.maxChunkSize) {
-                        chunkSize = self.maxChunkSize;
-                    }
-
                     // Reduce chunk size to fit total
                     if (offset + chunkSize > total) {
                         chunkSize = total - offset;


### PR DESCRIPTION
The README says the maxChunkSize option is only used if adaptive = true: https://lztc.qonq.gq
But this is not true; in the code there is a second copy of the "Limit to max chunk size" code, outside of the code block for adaptive mode. So either this should be removed to comply with the documentation, or the documentation should be updated; and in that case, the "Limit to max chunk size" code inside the adaptive block is unnecessary as the exact same code is ran again right after it.